### PR TITLE
drop xenial/sudo from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,12 @@ matrix:
       env:
         - TOXENV=py36,report,codecov
     - python: '3.7'
-      dist: xenial
-      sudo: required
       env:
         - TOXENV=py37,report,codecov
     - python: '3.7'
-      dist: xenial
-      sudo: required
       env:
         - TOXENV=doc
     - python: '3.7'
-      dist: xenial
-      sudo: required
       env:
         - TOXENV=check
 before_install:


### PR DESCRIPTION
While this used to be required it should not be anymore.