### PR TITLE
no cover for xfail'ed test_forward_reference()

### DIFF
--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -378,7 +378,7 @@ def test_newtype(module, assert_dump_load):
         + "See https://github.com/lovasoa/marshmallow_dataclass/issues/13"
     ),
 )
-def test_forward_reference(module, assert_dump_load):   # pragma: no cover
+def test_forward_reference(module, assert_dump_load):  # pragma: no cover
     """Build schemas from classes that are defined below their containing class."""
 
     @module.dataclass

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -378,7 +378,7 @@ def test_newtype(module, assert_dump_load):
         + "See https://github.com/lovasoa/marshmallow_dataclass/issues/13"
     ),
 )
-def test_forward_reference(module, assert_dump_load):
+def test_forward_reference(module, assert_dump_load):   # pragma: no cover
     """Build schemas from classes that are defined below their containing class."""
 
     @module.dataclass


### PR DESCRIPTION
`test_forward_reference()` is unconditionally xfail'ed and as such we don't expect it to get fully covered.  May as well not include it in coverage results then.