### PR TITLE
Remove always-true if in field_for_schema()

### DIFF
--- a/src/desert/_make.py
+++ b/src/desert/_make.py
@@ -213,10 +213,7 @@ def field_for_schema(
     if default is not marshmallow.missing:
         desert_metadata.setdefault("default", default)
         desert_metadata.setdefault("allow_none", True)
-        if not desert_metadata.get(
-            "required"
-        ):  # 'missing' must not be set for required fields.
-            desert_metadata.setdefault("missing", default)
+        desert_metadata.setdefault("missing", default)
 
     field = None
 


### PR DESCRIPTION
From what I can tell this condition can only be true if the calling code
doubly accessses internal things such as:

```python3
attr.ib(default=1, metadata={desert._make._DESERT_SENTINEL:{'required': True}})
```