### PR TITLE
Only require dataclasses backport for Python < 3.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
 marshmallow>=3.0
 attrs
 typing_inspect
-dataclasses
+dataclasses; python_version < "3.7"


### PR DESCRIPTION
Fixes #102