### PR TITLE
#100 Propagate meta dict to Nested dataclasses

### DIFF
--- a/changelog.d/100.propagate.rst
+++ b/changelog.d/100.propagate.rst
@@ -1,0 +1,1 @@
+Nested fields will now inherit their parent dataclass' metadata params so that `marshmallow.EXCLUDE` will propagate to child dataclasses.

--- a/src/desert/_make.py
+++ b/src/desert/_make.py
@@ -130,7 +130,7 @@ def class_schema(
             attributes[field.name] = field_for_schema(
                 hints.get(field.name, field.type),
                 _get_field_default(field),
-                field.metadata,
+                {**meta, **field.metadata},
             )
 
     cls_schema = type(
@@ -289,7 +289,8 @@ def field_for_schema(
 
     if field is None:
         nested = forward_reference or class_schema(typ)
-        field = marshmallow.fields.Nested(nested)
+        params = {k: v for k, v in metadata.items() if type(k) is str}
+        field = marshmallow.fields.Nested(nested, **params)
 
     field.metadata.update(metadata)
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -191,6 +191,22 @@ def test_nested(module):
     assert data == B(A(5))
 
 
+def test_nested_unknown(module):
+    """Schemas will propagate meta to Nested dataclasses."""
+
+    @module.dataclass
+    class A:
+        x: int
+
+    @module.dataclass
+    class B:
+        y: A
+
+    data = desert.schema_class(B, meta={"unknown": marshmallow.EXCLUDE})().load({"y": {"x": 5, "z": 3}})
+
+    assert data == B(A(5))
+
+
 def test_optional(module):
     """Setting an optional type makes the default None."""
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -202,7 +202,9 @@ def test_nested_unknown(module):
     class B:
         y: A
 
-    data = desert.schema_class(B, meta={"unknown": marshmallow.EXCLUDE})().load({"y": {"x": 5, "z": 3}})
+    data = desert.schema_class(B, meta={"unknown": marshmallow.EXCLUDE})().load(
+        {"y": {"x": 5, "z": 3}}
+    )
 
     assert data == B(A(5))
 


### PR DESCRIPTION
Hi there,

This PR changes default behavior for Nested dataclasses so that the `meta` dict that we pass into `desert.schema` will be propagated to all child dataclasses.

I've also taken the liberty of adding a test to demonstrate that it works as intended.

If you feel that this should not be default behavior, we can make this functionality live behind a feature flag `meta` dict that we can branch off of.

Fixes #100 