### PR TITLE
Fix Travis CI bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,8 @@ install:
   - |
     set -ex
     if [[ $TOXENV == 'check' ]]; then
-        (gem install travis --no-rdoc --no-ri
+        echo "gem: --no-document" >> ~/.gemrc
+        (gem install travis
          travis lint --no-interactive --exit-code)
     fi
     set +x


### PR DESCRIPTION
Refactoring `--no-rdoc --no-ri` into the `~/.gemrc` file like so should hopefully fix the false negatives we're seeing from the project's CI.

Relevant article: https://stackoverflow.com/questions/1381725/how-to-make-no-ri-no-rdoc-the-default-for-gem-install