### PR TITLE
use twine check instead of setup.py check

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,5 +1,6 @@
 versioneer
 black
+build
 pylint
 pex
 bump2version

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,7 +36,9 @@ bleach==3.3.1 \
 build==0.5.1 \
     --hash=sha256:0281eeec2697ee43114eb4fe3ba6e54c111ee2c4ef287b5cd24f82cb24cc1bdb \
     --hash=sha256:16897cac845b50cca04f3c92cf8d3e9e0868b21b29b96b577333c14473baa916
-    # via check-manifest
+    # via
+    #   -r dev-requirements.in
+    #   check-manifest
 bump2version==1.0.1 \
     --hash=sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410 \
     --hash=sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         ),
         re.sub(":[a-z]+:`~?(.*?)`", r"``\1``", read("CHANGELOG.rst")),
     ),
+    long_description_content_type="text/x-rst",
     author="Desert contributors",
     author_email="python-desert@users.noreply.github.com",
     url="https://github.com/python-desert/desert",

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,8 @@ deps =
      -r {toxinidir}/dev-requirements.txt
 skip_install = true
 commands =
-    python -m build
-    twine check --strict dist/*
+    python -m build --outdir {envtmpdir}/dist/
+    twine check --strict {envtmpdir}/dist/*
     check-manifest {toxinidir}
     black --check {toxinidir}
     isort --verbose --check-only --diff src tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,8 @@ deps =
      -r {toxinidir}/dev-requirements.txt
 skip_install = true
 commands =
-    twine check --strict
+    python -m build
+    twine check --strict dist/*
     check-manifest {toxinidir}
     black --check {toxinidir}
     isort --verbose --check-only --diff src tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
      -r {toxinidir}/dev-requirements.txt
 skip_install = true
 commands =
-    python setup.py check --strict --metadata --restructuredtext
+    twine check --strict
     check-manifest {toxinidir}
     black --check {toxinidir}
     isort --verbose --check-only --diff src tests setup.py


### PR DESCRIPTION
https://github.com/python-desert/desert/pull/94/checks?check_run_id=3253763805#step:5:16
```
[303] /__w/desert/desert$ /__w/desert/desert/.tox/check/bin/python setup.py check --strict --metadata --restructuredtext
running check
warning: Check: This command has been deprecated. Use `twine check` instead: packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup
```