### PR TITLE
fix package metadata after dropping py36

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
 marshmallow>=3.0
 attrs
 typing_inspect
-dataclasses; python_version < "3.7"

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     keywords=[
         # eg: "keyword1", "keyword2", "keyword3",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=INSTALL_REQUIRES
     # eg: "aspectlib==1.1.1", "six>=1.7",
     ,


### PR DESCRIPTION
A couple items missed after dropping py36 just for good housekeeping.

Unfortunately I didn't catch the python_requires metadata prior to release which would help prevent accidentally installing the new desert release on python 3.6. Fortunately I don't think the last release is actually broken on 3.6 so it's not a big deal this time. 3.6 was mainly dropped because of CI issues and the fact that it's EOL.