### PR TITLE
Support TypedDict field as Dict[str, Any]

### DIFF
--- a/changelog.d/237.change.rst
+++ b/changelog.d/237.change.rst
@@ -1,0 +1,1 @@
+Add `TypedDict` subclass support to fields. These are treated the same as `Dict[str, Any]`.


### PR DESCRIPTION
Title says it all. Nothing to fancy, just a simple mapping of `TypedDict` -> `Dict[str, Any]`