### PR TITLE
Use Marshmallow's native Enum field if possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         # uncomment if you test on these interpreters:


### PR DESCRIPTION
This allows us to remove the dependency on `marshmallow_enum` if `marshmallow` 3.18+ is installed.

Changes
* Use `marshmallow.fields.Enum` if present (added in 3.18)
* Explicitly throw `UnknownFieldError` if an enum is encountered but an implementation is not available. Previously, this would throw an `ImportError` for `marshmallow_enum` which is confusing for users not familiar with this requirement.

Other changes:
* Removed unused imports
* Removed nonexistent items from `__all__`
* Added 3.10 and 3.11 to the trove classifiers