### PR TITLE
Isra/optional default

### DIFF
--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -224,6 +224,17 @@ def test_optional_present(module: DataclassModule) -> None:
     assert data == A(None)  # type: ignore[call-arg]
 
 
+def test_optional_default(module: DataclassModule) -> None:
+    """Setting an optional type allows passing None."""
+
+    @module.dataclass
+    class A:
+        x: t.Optional[int] = 1
+
+    data = desert.schema_class(A)().load({})
+    assert data == A(1)  # type: ignore[call-arg]
+
+
 def test_custom_field(module: DataclassModule) -> None:
     @module.dataclass
     class A:


### PR DESCRIPTION
I was investigating why `Optional` default was broken (ie. `x: Optional[int] = 1` would default to `None`) and ended up refactoring a good bunch of the code, finding out that defaults seemed to be overall quite broken.